### PR TITLE
[NeoForge 1.21.1] Support Controlify (UPDATE: REVERTED, SEE PR #8)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,12 +69,25 @@ sourceSets.main.resources { srcDir 'src/generated/resources' }
 
 
 dependencies {
-    implementation "curse.maven:epic-fight-mod-405076:7106604-sources-7106644"
+    implementation "maven.modrinth:epic-fight:21.13.3.2"
+    // Change "compileOnly" to "implementation" for testing in-game.
+    compileOnly("dev.isxander:controlify:${project.controlify_version}") {
+        // Only need Controlify API, ignore the transitive dependencies (e.g, QuiltMC parsers)
+        transitive = false
+    }
 }
 
 repositories {
     maven { url = "https://cursemaven.com" }
     mavenLocal()
+    exclusiveContent {
+        forRepository { maven { name = "Modrinth"; url = "https://api.modrinth.com/maven" } }
+        filter { includeGroup "maven.modrinth" }
+    }
+    exclusiveContent {
+        forRepository { maven { url "https://maven.isxander.dev/releases" } }
+        filter { includeGroup "dev.isxander" }
+    }
 }
 
 var generateModMetadata = tasks.register("generateModMetadata", ProcessResources) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -41,7 +41,5 @@ mod_authors=P1nero
 # The description of the mod. This is a simple multiline text string that is used for display purposes in the mod list.
 mod_description=Make efm addon developers easier to create complex combo weapon types.
 
-systemProp.http.proxyHost=localhost
-systemProp.http.proxyPort=7890
-systemProp.https.proxyHost=localhost
-systemProp.https.proxyPort=7890
+# Dependencies
+controlify_version=2.4.3+1.21.1-neoforge

--- a/src/main/java/com/p1nero/invincible/InvincibleMod.java
+++ b/src/main/java/com/p1nero/invincible/InvincibleMod.java
@@ -9,12 +9,14 @@ import com.p1nero.invincible.gameassets.InvincibleSkills;
 import com.p1nero.invincible.item.InvincibleItems;
 import com.p1nero.invincible.api.combo.ComboNode;
 import com.p1nero.invincible.api.combo.ComboType;
+import net.minecraft.resources.ResourceLocation;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.fml.ModContainer;
 import net.neoforged.fml.common.Mod;
 import net.neoforged.fml.config.ModConfig;
 import net.neoforged.fml.event.lifecycle.FMLClientSetupEvent;
 import net.neoforged.fml.event.lifecycle.FMLCommonSetupEvent;
+import org.jetbrains.annotations.NotNull;
 
 @Mod(InvincibleMod.MOD_ID)
 public class InvincibleMod {
@@ -41,4 +43,7 @@ public class InvincibleMod {
         InputManager.init();
     }
 
+    public static @NotNull ResourceLocation rl(@NotNull String path) {
+        return ResourceLocation.fromNamespaceAndPath(MOD_ID, path);
+    }
 }

--- a/src/main/java/com/p1nero/invincible/client/InputManager.java
+++ b/src/main/java/com/p1nero/invincible/client/InputManager.java
@@ -2,7 +2,6 @@ package com.p1nero.invincible.client;
 
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
-import com.mojang.blaze3d.platform.InputConstants;
 import com.p1nero.invincible.Config;
 import com.p1nero.invincible.InvincibleFlags;
 import com.p1nero.invincible.InvincibleMod;
@@ -21,7 +20,6 @@ import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.client.event.ClientTickEvent;
-import net.neoforged.neoforge.client.event.InputEvent;
 import net.neoforged.neoforge.registries.DeferredHolder;
 import org.jetbrains.annotations.NotNull;
 import yesman.epicfight.api.neoevent.playerpatch.SkillCastEvent;
@@ -44,7 +42,7 @@ public class InputManager {
     private static int reserveCounter;
     private static long lastInputTime;
     private static long inputInterval;
-    private static final BiMap<ComboType, KeyMapping> TYPE_KEY_MAP = HashBiMap.create();
+    private static final BiMap<ComboType, @NotNull  KeyMapping> TYPE_KEY_MAP = HashBiMap.create();
     private static BiMap<KeyMapping, ComboType> KEY_TYPE_MAP = HashBiMap.create();
     private static final Map<Integer, Integer> KEY_STATE_CACHE = new HashMap<>();
     private static final Queue<Integer> INPUT_QUEUE = new ArrayDeque<>();
@@ -99,6 +97,8 @@ public class InputManager {
      */
     @SubscribeEvent
     public static void onClientTick(ClientTickEvent.Post event) {
+        onHandleInput();
+
         LocalPlayerPatch localPlayerPatch = ClientEngine.getInstance().getPlayerPatch();
 
         if (localPlayerPatch != null) {
@@ -164,39 +164,41 @@ public class InputManager {
         }
     }
 
-    @SubscribeEvent
-    public static void onMouseInput(InputEvent.MouseButton.Pre event) {
-        handleInput(event.getButton(), event.getAction());
-    }
-
-    @SubscribeEvent
-    public static void onKeyInput(InputEvent.Key event) {
-        handleInput(event.getKey(), event.getAction());
-    }
-
     /**
      * 按下时记录
      * 松手时发包
      */
-    private static void handleInput(int key, int action) {
+    private static void onHandleInput() {
+        Minecraft mc = Minecraft.getInstance();
+        if (mc.screen != null || mc.isPaused()) return;
+
         LocalPlayerPatch playerPatch = ClientEngine.getInstance().getPlayerPatch();
-        if (playerPatch != null && Minecraft.getInstance().screen == null && !Minecraft.getInstance().isPaused()
-                && playerPatch.getSkill(SkillSlots.WEAPON_INNATE).getSkill() instanceof ComboBasicAttack) {
-            if (action == InputConstants.PRESS) {
-                for (KeyMapping keyMapping : TYPE_KEY_MAP.values()) {
-                    int keyId = keyMapping.getKey().getValue();
-                    if (key == keyId) {
-                        handleOnPress(keyMapping);
-                        if (!INPUT_QUEUE.contains(keyId)) {
-                            INPUT_QUEUE.add(keyId);
-                        }
-                        KEY_STATE_CACHE.put(keyId, KEY_STATE_CACHE.getOrDefault(keyId, 0) + 1);
-                        clearReservedKeys();
-                    }
+        if (playerPatch == null) return;
+
+        if (!(playerPatch.getSkill(SkillSlots.WEAPON_INNATE).getSkill() instanceof ComboBasicAttack)) {
+            return;
+        }
+
+        for (KeyMapping keyMapping : TYPE_KEY_MAP.values()) {
+            final int keyId = keyMapping.getKey().getValue();
+
+            while (keyMapping.consumeClick()) {
+                if (INPUT_QUEUE.contains(keyId)) {
+                    continue;
                 }
+                handleOnPress(keyMapping);
+                INPUT_QUEUE.add(keyId);
+                KEY_STATE_CACHE.put(keyId, KEY_STATE_CACHE.getOrDefault(keyId, 0) + 1);
+                clearReservedKeys();
             }
-            if (action == InputConstants.RELEASE) {
+
+            final boolean isDown = keyMapping.isDown();
+            final boolean wasDownBefore = KEY_STATE_CACHE.getOrDefault(keyId, 0) > 0;
+            final boolean isJustReleased = !isDown && wasDownBefore;
+            if (isJustReleased) {
                 tryRequestSkillExecute(true);
+                INPUT_QUEUE.remove(keyId);
+                KEY_STATE_CACHE.put(keyId, 0);
             }
         }
     }

--- a/src/main/java/com/p1nero/invincible/compat/controlify/ControlifyCompat.java
+++ b/src/main/java/com/p1nero/invincible/compat/controlify/ControlifyCompat.java
@@ -1,0 +1,135 @@
+package com.p1nero.invincible.compat.controlify;
+
+import com.p1nero.invincible.InvincibleMod;
+import com.p1nero.invincible.client.InvincibleKeyMappings;
+import dev.isxander.controlify.api.ControlifyApi;
+import dev.isxander.controlify.api.bind.ControlifyBindApi;
+import dev.isxander.controlify.api.bind.InputBindingSupplier;
+import dev.isxander.controlify.api.entrypoint.ControlifyEntrypoint;
+import dev.isxander.controlify.api.entrypoint.InitContext;
+import dev.isxander.controlify.api.entrypoint.PreInitContext;
+import dev.isxander.controlify.bindings.BindContext;
+import dev.isxander.controlify.bindings.RadialIcons;
+import dev.isxander.controlify.utils.render.Blit;
+import dev.isxander.controlify.utils.render.CGuiPose;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+import org.jetbrains.annotations.NotNull;
+import yesman.epicfight.client.ClientEngine;
+
+public class ControlifyCompat implements ControlifyEntrypoint {
+    private static InputBindingSupplier primaryAction;
+    private static InputBindingSupplier secondaryAction;
+    private static InputBindingSupplier specialAbility1;
+    private static InputBindingSupplier specialAbility2;
+
+    @Override
+    public void onControllersDiscovered(ControlifyApi controlify) {
+
+    }
+
+    @Override
+    public void onControlifyInit(InitContext context) {
+
+    }
+
+    @Override
+    public void onControlifyPreInit(PreInitContext context) {
+        final ControlifyBindApi registrar = ControlifyBindApi.get();
+        registerCustomRadialIcons();
+        registrar.registerBindContext(IN_GAME_EPIC_FIGHT_CONTEXT);
+        registerInputBindings(registrar);
+    }
+
+    private static void registerInputBindings(ControlifyBindApi registrar) {
+        primaryAction = registrar.registerBinding(
+                builder -> builder.id(InvincibleMod.rl("primary_action"))
+                        .category(ComponentConstants.COMMON_CATEGORY)
+                        .allowedContexts(IN_GAME_EPIC_FIGHT_CONTEXT)
+                        .name(ComponentConstants.PRIMARY_ACTION)
+                        .description(ComponentConstants.PRIMARY_ACTION_DESCRIPTION)
+                        .addKeyCorrelation(InvincibleKeyMappings.KEY1)
+                        .keyEmulation(InvincibleKeyMappings.KEY1)
+        );
+        secondaryAction = registrar.registerBinding(
+                builder -> builder.id(InvincibleMod.rl("secondary_action"))
+                        .category(ComponentConstants.COMMON_CATEGORY)
+                        .allowedContexts(IN_GAME_EPIC_FIGHT_CONTEXT)
+                        .name(ComponentConstants.SECONDARY_ACTION)
+                        .description(ComponentConstants.SECONDARY_ACTION_DESCRIPTION)
+                        .addKeyCorrelation(InvincibleKeyMappings.KEY2)
+                        .keyEmulation(InvincibleKeyMappings.KEY2)
+        );
+        specialAbility1 = registrar.registerBinding(
+                builder -> builder.id(InvincibleMod.rl("special_ability_1"))
+                        .category(ComponentConstants.COMMON_CATEGORY)
+                        .allowedContexts(IN_GAME_EPIC_FIGHT_CONTEXT)
+                        .name(ComponentConstants.SPECIAL_ABILITY_1)
+                        .description(ComponentConstants.SPECIAL_ABILITY_1_DESCRIPTION)
+                        .addKeyCorrelation(InvincibleKeyMappings.KEY3)
+                        .keyEmulation(InvincibleKeyMappings.KEY3)
+                        .radialCandidate(InvincibleRadialIcons.COMBO_ATTACKS.getId())
+        );
+        specialAbility2 = registrar.registerBinding(
+                builder -> builder.id(InvincibleMod.rl("special_ability_2"))
+                        .category(ComponentConstants.COMMON_CATEGORY)
+                        .allowedContexts(IN_GAME_EPIC_FIGHT_CONTEXT)
+                        .name(ComponentConstants.SPECIAL_ABILITY_2)
+                        .description(ComponentConstants.SPECIAL_ABILITY_2_DESCRIPTION)
+                        .addKeyCorrelation(InvincibleKeyMappings.KEY4)
+                        .keyEmulation(InvincibleKeyMappings.KEY4)
+                        .radialCandidate(InvincibleRadialIcons.COMBO_ATTACKS.getId())
+        );
+    }
+
+    private enum InvincibleRadialIcons {
+        COMBO_ATTACKS(InvincibleMod.rl("textures/gui/skills/weapon_innate/combo_attacks.png"));
+
+        private final @NotNull ResourceLocation id;
+
+        InvincibleRadialIcons(@NotNull ResourceLocation id) {
+            this.id = id;
+        }
+
+        public @NotNull ResourceLocation getId() {
+            return id;
+        }
+    }
+
+    private static void registerCustomRadialIcons() {
+        for (InvincibleRadialIcons icon : InvincibleRadialIcons.values()) {
+            final ResourceLocation location = icon.getId();
+            RadialIcons.registerIcon(location, (graphics, x, y, tickDelta) -> {
+                var pose = CGuiPose.ofPush(graphics);
+                pose.translate(x, y);
+                pose.scale(0.5f, 0.5f);
+                Blit.tex(graphics, location, 0, 0, 0, 0, 32, 32, 32, 32);
+                pose.pop();
+            });
+        }
+    }
+
+    private static final BindContext IN_GAME_EPIC_FIGHT_CONTEXT = new BindContext(
+            InvincibleMod.rl("epicfight_combat"),
+            mc -> {
+                final boolean isInGame = mc.screen == null && mc.level != null && mc.player != null;
+                return isInGame && ClientEngine.getInstance().isEpicFightMode();
+            }
+    );
+
+    private static class ComponentConstants {
+        private static final Component COMMON_CATEGORY = Component.translatable("key.invincible.category");
+
+        // Names
+        private static final Component PRIMARY_ACTION = Component.translatable("key.invincible.key1");
+        private static final Component SECONDARY_ACTION = Component.translatable("key.invincible.key2");
+        private static final Component SPECIAL_ABILITY_1 = Component.translatable("key.invincible.key3");
+        private static final Component SPECIAL_ABILITY_2 = Component.translatable("key.invincible.key4");
+
+        // Descriptions
+        private static final Component PRIMARY_ACTION_DESCRIPTION = Component.translatable("key.invincible.key1.description");
+        private static final Component SECONDARY_ACTION_DESCRIPTION = Component.translatable("key.invincible.key2.description");
+        private static final Component SPECIAL_ABILITY_1_DESCRIPTION = Component.translatable("key.invincible.key3.description");
+        private static final Component SPECIAL_ABILITY_2_DESCRIPTION = Component.translatable("key.invincible.key4.description");
+    }
+}

--- a/src/main/resources/META-INF/services/dev.isxander.controlify.api.entrypoint.ControlifyEntrypoint
+++ b/src/main/resources/META-INF/services/dev.isxander.controlify.api.entrypoint.ControlifyEntrypoint
@@ -1,0 +1,1 @@
+com.p1nero.invincible.compat.controlify.ControlifyCompat

--- a/src/main/resources/assets/controlify/controllers/default_bind/default.json
+++ b/src/main/resources/assets/controlify/controllers/default_bind/default.json
@@ -1,0 +1,10 @@
+{
+  "defaults": {
+    "invincible:primary_action": {
+      "axis": "controlify:axis/right_trigger"
+    },
+    "invincible:secondary_action": {
+      "axis": "controlify:axis/left_trigger"
+    }
+  }
+}

--- a/src/main/resources/assets/invincible/lang/en_us.json
+++ b/src/main/resources/assets/invincible/lang/en_us.json
@@ -1,9 +1,13 @@
 {
-  "key.invincible.key1": "KEY1",
-  "key.invincible.key2": "KEY2",
-  "key.invincible.key3": "KEY3",
-  "key.invincible.key4": "KEY4",
-  "key.invincible.category": "Invincible Key",
+  "key.invincible.key1": "Primary Action",
+  "key.invincible.key2": "Secondary Action",
+  "key.invincible.key3": "Special Ability 1",
+  "key.invincible.key4": "Special Ability 2",
+  "key.invincible.key1.description": "Usually performs your main attack or primary combat action.",
+  "key.invincible.key2.description": "Commonly used for blocking, aiming, or secondary combat actions.",
+  "key.invincible.key3.description": "Triggers a special ability or alternate skill when available.",
+  "key.invincible.key4.description": "Activates an additional special or support ability if assigned.",
+  "key.invincible.category": "Invincible Actions",
   "tips.invincible.charge": "Long Press KEY2 to charge.",
   "commands.invincible.reload": "[Invincible Lib]: Skills Reloaded!"
 }


### PR DESCRIPTION
> [!TIP]
> Now that Epic Fight supports Controlify in version [21.13.3.2](https://modrinth.com/mod/epic-fight/version/21.13.3.2) and newer, it's time to start adapting this change so all users can experience the different Epic Fight addons. For more details, refer to this issue: https://github.com/Epic-Fight/epicfight/issues/2116

**See also the PR sent to Sword Soaring https://github.com/GaylordFockerCN/SwordSoaring-Reborn/pull/7**

### Demo

<details><summary>Sword Soaring - Vatansever Weapon</summary>
<p>

I tested this PR with Sword Soaring, since this mod is a library and does not have any content on its own.

The Epic Fight Sword Soaring mod depends on this mod to attack when using the Vatansever Weapon, so even if https://github.com/GaylordFockerCN/SwordSoaring-Reborn/pull/7 is merged, without this PR, controller users can't attack using a controller.

https://github.com/user-attachments/assets/1586617f-f27e-4c08-a6a8-8ebe61a90a01

I have also confirmed that the attack works on keyboard and mouse too:

https://github.com/user-attachments/assets/ce0db3b5-ab82-4424-aa2b-dc40869c4e3c

</p>
</details> 

### Changes

- Adds Controlify integration, input bindings, descriptions, and registers key emulation.
- Migrates to `ClientTickEvent.Post` instead of input events, as a universal fix to support controllers (via key emulation). This is [the NeoForge recommended way of handling input](https://docs.neoforged.net/docs/misc/keymappings/#within-the-game). FYI: Same fix applied in https://github.com/GaylordFockerCN/SwordSoaring-Reborn/pull/7