### PR TITLE
[Forge 1.20.1] (DEVELOPMENT_ONLY) Fix Controlify Forgefied development MinecraftForge mapping issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -131,7 +131,13 @@ repositories {
     }
     exclusiveContent {
         forRepository { maven { url "https://echoellet.github.io/Controlify/" } }
+        forRepositories(fg.repository)
         filter { includeGroup "dev.echoellet" }
+    }
+    exclusiveContent {
+        forRepository { maven { name = "Modrinth"; url = "https://api.modrinth.com/maven" } }
+        forRepositories(fg.repository)
+        filter { includeGroup "maven.modrinth" }
     }
 }
 
@@ -140,11 +146,8 @@ dependencies {
     annotationProcessor 'org.spongepowered:mixin:0.8.5:processor'
     implementation fg.deobf("curse.maven:epic-fight-mod-405076:7129220-sources-7129223")
 
-    // Change "compileOnly" to "implementation" for testing in-game.
-    compileOnly("dev.echoellet:controlify-forgified:${project.controlify_version}") {
-        // Only need Controlify API, ignore the transitive dependencies (e.g, QuiltMC parsers)
-        transitive = false
-    }
+    implementation fg.deobf("dev.echoellet:controlify-forgified:${project.controlify_version}")
+    runtimeOnly fg.deobf("maven.modrinth:yacl:3.6.6+1.20.1-forge") // Required to run Controlify (transitive dependency)
 }
 
 // This block of code expands all declared replace properties in the specified resource targets.

--- a/build.gradle
+++ b/build.gradle
@@ -144,10 +144,11 @@ repositories {
 dependencies {
     minecraft "net.minecraftforge:forge:${minecraft_version}-${forge_version}"
     annotationProcessor 'org.spongepowered:mixin:0.8.5:processor'
-    implementation fg.deobf("curse.maven:epic-fight-mod-405076:7129220-sources-7129223")
+    implementation fg.deobf("maven.modrinth:epic-fight:20.13.4-1.20.1")
 
     implementation fg.deobf("dev.echoellet:controlify-forgified:${project.controlify_version}")
     runtimeOnly fg.deobf("maven.modrinth:yacl:3.6.6+1.20.1-forge") // Required to run Controlify (transitive dependency)
+    runtimeOnly fg.deobf("maven.modrinth:epic-fight-controlify:0.0.1-mc1.20.1-forge") // Optional for Epic Fight X Controlify integration (required on 1.20.1 only, built-in in Epic fight 1.21.1)
 }
 
 // This block of code expands all declared replace properties in the specified resource targets.

--- a/gradle.properties
+++ b/gradle.properties
@@ -46,4 +46,4 @@ mod_authors=P1nero
 mod_description=Make Epic Fight addon developers easier to create complex combo weapon types.
 
 # Dependencies
-controlify_version=2.1.3-mc1.20.1-forge
+controlify_version=2.1.6-mc1.20.1-forge

--- a/src/main/java/com/p1nero/invincible/compat/controlify/ControlifyCompat.java
+++ b/src/main/java/com/p1nero/invincible/compat/controlify/ControlifyCompat.java
@@ -83,7 +83,7 @@ public class ControlifyCompat implements ControlifyEntrypoint {
     }
 
     private enum InvincibleRadialIcons {
-        COMBO_ATTACKS(InvincibleMod.rl("textures/gui/skills/weapon_innate/combo_attacks.png"));
+        COMBO_ATTACKS(InvincibleMod.rl("textures/gui/skills/weapon_innate/combo_demo.png"));
 
         private final @NotNull ResourceLocation id;
 


### PR DESCRIPTION
Same as https://github.com/GaylordFockerCN/SwordSoaring-Reborn/pull/9, but for Invincible Lib.

This fixes an issue during development only, and it fixes an unrelated minor issue too; the radial menu texture was missing, since it has been renamed in 1.21.1, and this was a backport to 1.20.1.