### PR TITLE
[Forge 1.20.1] Revert the InputManager changes introduced by Controlify compatibility

### DIFF
--- a/src/main/java/com/p1nero/invincible/client/InputManager.java
+++ b/src/main/java/com/p1nero/invincible/client/InputManager.java
@@ -1,14 +1,13 @@
 package com.p1nero.invincible.client;
 
-import com.google.common.collect.BiMap;
-import com.google.common.collect.HashBiMap;
+import com.mojang.blaze3d.platform.InputConstants;
 import com.p1nero.invincible.InvincibleConfig;
 import com.p1nero.invincible.InvincibleMod;
 import com.p1nero.invincible.api.events.Side;
 import com.p1nero.invincible.api.skill.ComboNode;
 import com.p1nero.invincible.api.skill.ComboType;
-import com.p1nero.invincible.capability.InvinciblePlayer;
 import com.p1nero.invincible.capability.InvinciblePlayerCapabilityProvider;
+import com.p1nero.invincible.capability.InvinciblePlayer;
 import com.p1nero.invincible.gameassets.InvincibleSkillDataKeys;
 import com.p1nero.invincible.skill.AbstractInvincibleInnateSkill;
 import com.p1nero.invincible.skill.ComboBasicAttack;
@@ -16,10 +15,10 @@ import net.minecraft.client.KeyMapping;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.Options;
 import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.client.event.InputEvent;
 import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
-import org.jetbrains.annotations.NotNull;
 import yesman.epicfight.client.ClientEngine;
 import yesman.epicfight.client.input.EpicFightKeyMappings;
 import yesman.epicfight.client.world.capabilites.entitypatch.player.LocalPlayerPatch;
@@ -40,7 +39,7 @@ public class InputManager {
     private static int reserveCounter;
     private static long lastInputTime;
     private static long inputInterval;
-    private static final BiMap<ComboType, @NotNull KeyMapping> TYPE_KEY_MAP = HashBiMap.create();
+    private static final Map<ComboType, KeyMapping> TYPE_KEY_MAP = new HashMap<>();
     private static final Map<Integer, Integer> KEY_STATE_CACHE = new HashMap<>();
     private static final Queue<Integer> INPUT_QUEUE = new ArrayDeque<>();
     private static ComboNode currentNode;
@@ -96,7 +95,6 @@ public class InputManager {
         if (event.phase == TickEvent.Phase.START || Minecraft.getInstance().player == null) {
             return;
         }
-        onHandleInput();
         LocalPlayerPatch localPlayerPatch = ClientEngine.getInstance().getPlayerPatch();
         if (localPlayerPatch != null && Minecraft.getInstance().getConnection() != null) {
             //缓存的按键的处理
@@ -141,38 +139,41 @@ public class InputManager {
         }
     }
 
+    // TODO: Refactor handleInput() to not depend on any "InputEvent"s to support controllers.
+    //  See the related issue: https://github.com/GaylordFockerCN/EpicFight-Invincible/issues/3
+
+    @SubscribeEvent
+    public static void onMouseInput(InputEvent.MouseButton event) {
+        handleInput(event.getButton(), event.getAction());
+    }
+
+    @SubscribeEvent
+    public static void onKeyInput(InputEvent.Key event) {
+        handleInput(event.getKey(), event.getAction());
+    }
+
     /**
      * 按下时记录
      * 松手时发包
      */
-    private static void onHandleInput() {
-        Minecraft mc = Minecraft.getInstance();
-        if (mc.screen != null || mc.isPaused()) return;
-
+    private static void handleInput(int key, int action) {
         LocalPlayerPatch playerPatch = ClientEngine.getInstance().getPlayerPatch();
-        if (playerPatch == null) return;
-        if (!(playerPatch.getSkill(SkillSlots.WEAPON_INNATE).getSkill() instanceof ComboBasicAttack)) {
-            return;
-        }
-        for (KeyMapping keyMapping : TYPE_KEY_MAP.values()) {
-            final int keyId = keyMapping.getKey().getValue();
-
-            while (keyMapping.consumeClick()) {
-                if (INPUT_QUEUE.contains(keyId)) {
-                    continue;
+        if (playerPatch != null && Minecraft.getInstance().screen == null && !Minecraft.getInstance().isPaused()
+                && playerPatch.getSkill(SkillSlots.WEAPON_INNATE).getSkill() instanceof ComboBasicAttack) {
+            if (action == InputConstants.PRESS) {
+                for (KeyMapping keyMapping : TYPE_KEY_MAP.values()) {
+                    int keyId = keyMapping.getKey().getValue();
+                    if (key == keyId) {
+                        if (!INPUT_QUEUE.contains(keyId)) {
+                            INPUT_QUEUE.add(keyId);
+                        }
+                        KEY_STATE_CACHE.put(keyId, KEY_STATE_CACHE.getOrDefault(keyId, 0) + 1);
+                        clearReservedKeys();
+                    }
                 }
-                INPUT_QUEUE.add(keyId);
-                KEY_STATE_CACHE.put(keyId, KEY_STATE_CACHE.getOrDefault(keyId, 0) + 1);
-                clearReservedKeys();
             }
-
-            final boolean isDown = keyMapping.isDown();
-            final boolean wasDownBefore = KEY_STATE_CACHE.getOrDefault(keyId, 0) > 0;
-            final boolean isJustReleased = !isDown && wasDownBefore;
-            if (isJustReleased) {
+            if (action == InputConstants.RELEASE) {
                 tryRequestSkillExecute(true);
-                INPUT_QUEUE.remove(keyId);
-                KEY_STATE_CACHE.put(keyId, 0);
             }
         }
     }


### PR DESCRIPTION
This PR restores the `InputManager` state to the state exactly before any Controlify changes, specifically to [this commit](https://github.com/GaylordFockerCN/EpicFight-Invincible/blob/3bf3e3545ac75d5f5c2e3daec784b68557145597/src/main/java/com/p1nero/invincible/client/InputManager.java). This has been done due to the regression that was introduced, which affects vanilla mouse and keyboard users too.

This makes Controlify no longer usable, but it's not a full revert, as soon as we address the issue in Invincible's `InputManager`, by migrating to `ClientTickEvent` fully, the Controlify key emulation will work once again.

Also added a TODO so we can keep track of this issue. I will do my best to work on this issue again, as soon as I'm done with https://github.com/Epic-Fight/epicfight/issues/2170 (and some other priorities).

I may take some time, but the new behavior is exactly as it was, no changes, and no Controlify support, but also not a full revert. For example, radial menu, Controlify descriptions, and other changes are retained, but they are not useful without this `InputManager` fix, which is why I added the TODO.

It's good that the issue https://github.com/GaylordFockerCN/EpicFight-Invincible/issues/3 is still open.
