### PR TITLE
[NeoForge 1.21.1] Revert the InputManager changes introduced by Controlify compatibility

### DIFF
--- a/src/main/java/com/p1nero/invincible/client/InputManager.java
+++ b/src/main/java/com/p1nero/invincible/client/InputManager.java
@@ -2,6 +2,7 @@ package com.p1nero.invincible.client;
 
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
+import com.mojang.blaze3d.platform.InputConstants;
 import com.p1nero.invincible.InvincibleConfig;
 import com.p1nero.invincible.InvincibleFlags;
 import com.p1nero.invincible.InvincibleMod;
@@ -20,6 +21,7 @@ import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.client.event.ClientTickEvent;
+import net.neoforged.neoforge.client.event.InputEvent;
 import net.neoforged.neoforge.registries.DeferredHolder;
 import org.jetbrains.annotations.NotNull;
 import yesman.epicfight.api.neoevent.playerpatch.SkillCastEvent;
@@ -42,7 +44,7 @@ public class InputManager {
     private static int reserveCounter;
     private static long lastInputTime;
     private static long inputInterval;
-    private static final BiMap<ComboType, @NotNull  KeyMapping> TYPE_KEY_MAP = HashBiMap.create();
+    private static final BiMap<ComboType, KeyMapping> TYPE_KEY_MAP = HashBiMap.create();
     private static BiMap<KeyMapping, ComboType> KEY_TYPE_MAP = HashBiMap.create();
     private static final Map<Integer, Integer> KEY_STATE_CACHE = new HashMap<>();
     private static final Queue<Integer> INPUT_QUEUE = new ArrayDeque<>();
@@ -97,8 +99,6 @@ public class InputManager {
      */
     @SubscribeEvent
     public static void onClientTick(ClientTickEvent.Post event) {
-        onHandleInput();
-
         LocalPlayerPatch localPlayerPatch = ClientEngine.getInstance().getPlayerPatch();
 
         if (localPlayerPatch != null) {
@@ -164,41 +164,42 @@ public class InputManager {
         }
     }
 
+    // TODO: Refactor handleInput() to not depend on any "InputEvent"s to support controllers.
+    //  See the related issue: https://github.com/GaylordFockerCN/EpicFight-Invincible/issues/3
+
+    @SubscribeEvent
+    public static void onMouseInput(InputEvent.MouseButton.Pre event) {
+        handleInput(event.getButton(), event.getAction());
+    }
+
+    @SubscribeEvent
+    public static void onKeyInput(InputEvent.Key event) {
+        handleInput(event.getKey(), event.getAction());
+    }
+
     /**
      * 按下时记录
      * 松手时发包
      */
-    private static void onHandleInput() {
-        Minecraft mc = Minecraft.getInstance();
-        if (mc.screen != null || mc.isPaused()) return;
-
+    private static void handleInput(int key, int action) {
         LocalPlayerPatch playerPatch = ClientEngine.getInstance().getPlayerPatch();
-        if (playerPatch == null) return;
-
-        if (!(playerPatch.getSkill(SkillSlots.WEAPON_INNATE).getSkill() instanceof ComboBasicAttack)) {
-            return;
-        }
-
-        for (KeyMapping keyMapping : TYPE_KEY_MAP.values()) {
-            final int keyId = keyMapping.getKey().getValue();
-
-            while (keyMapping.consumeClick()) {
-                if (INPUT_QUEUE.contains(keyId)) {
-                    continue;
+        if (playerPatch != null && Minecraft.getInstance().screen == null && !Minecraft.getInstance().isPaused()
+                && playerPatch.getSkill(SkillSlots.WEAPON_INNATE).getSkill() instanceof ComboBasicAttack) {
+            if (action == InputConstants.PRESS) {
+                for (KeyMapping keyMapping : TYPE_KEY_MAP.values()) {
+                    int keyId = keyMapping.getKey().getValue();
+                    if (key == keyId) {
+                        handleOnPress(keyMapping);
+                        if (!INPUT_QUEUE.contains(keyId)) {
+                            INPUT_QUEUE.add(keyId);
+                        }
+                        KEY_STATE_CACHE.put(keyId, KEY_STATE_CACHE.getOrDefault(keyId, 0) + 1);
+                        clearReservedKeys();
+                    }
                 }
-                handleOnPress(keyMapping);
-                INPUT_QUEUE.add(keyId);
-                KEY_STATE_CACHE.put(keyId, KEY_STATE_CACHE.getOrDefault(keyId, 0) + 1);
-                clearReservedKeys();
             }
-
-            final boolean isDown = keyMapping.isDown();
-            final boolean wasDownBefore = KEY_STATE_CACHE.getOrDefault(keyId, 0) > 0;
-            final boolean isJustReleased = !isDown && wasDownBefore;
-            if (isJustReleased) {
+            if (action == InputConstants.RELEASE) {
                 tryRequestSkillExecute(true);
-                INPUT_QUEUE.remove(keyId);
-                KEY_STATE_CACHE.put(keyId, 0);
             }
         }
     }


### PR DESCRIPTION
Same as #6, but for NeoForge 1.21.1