### PR TITLE
[1.20.1] Restore Controlify support

### DIFF
--- a/src/main/java/com/p1nero/invincible/client/InputManager.java
+++ b/src/main/java/com/p1nero/invincible/client/InputManager.java
@@ -8,9 +8,13 @@ import com.p1nero.invincible.api.skill.ComboNode;
 import com.p1nero.invincible.api.skill.ComboType;
 import com.p1nero.invincible.capability.InvinciblePlayerCapabilityProvider;
 import com.p1nero.invincible.capability.InvinciblePlayer;
+import com.p1nero.invincible.compat.controlify.ControlifyCompat;
 import com.p1nero.invincible.gameassets.InvincibleSkillDataKeys;
 import com.p1nero.invincible.skill.AbstractInvincibleInnateSkill;
 import com.p1nero.invincible.skill.ComboBasicAttack;
+import dev.isxander.controlify.api.ControlifyApi;
+import dev.isxander.controlify.api.bind.InputBindingSupplier;
+import dev.isxander.controlify.controller.ControllerEntity;
 import net.minecraft.client.KeyMapping;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.Options;
@@ -96,6 +100,7 @@ public class InputManager {
             return;
         }
         handleKeyBinds();
+        maybeHandleControlifyRelease();
         LocalPlayerPatch localPlayerPatch = ClientEngine.getInstance().getPlayerPatch();
         if (localPlayerPatch != null && Minecraft.getInstance().getConnection() != null) {
             //缓存的按键的处理
@@ -156,14 +161,36 @@ public class InputManager {
         }
     }
 
-    // TODO: handleRelease() is not called when using a controller,
-    //  this is mainly because Controlify key emulation does not work
-    //  "InputEvent"s, only vanilla KeyMapping.
-    //  The main reason why we use "InputEvent"s is that in Minecraft versions before 1.21.10,
-    //  "isDown()" method, (which is required to determine whether the key is down),
-    //  always returns "false" in MC 1.21.1 and 1.20.1 when there are
-    //  multiple keybinds bound to the same physical mouse button,
-    //  so the key release will be broken.
+    // TODO: Ideally, we should call handleRelease() from one place and provide
+    //  standard handling for both controllers and mouse/keyboard without depending on "InputEvents"s
+    //  or Controlify APIs directly.
+    //  However, it's tricky since "KeyMapping#isDown" returns false whenever there are multiple keybinds
+    //  that are bound to the same physical mouse button.
+    //  As a workaround, we handle mouse/keyboard via "InputEvents"s, and Controlify via this method.
+    //  The keybind presses handling is shared for all inputs using handleKeyBinds()
+    //  This HACK can be eliminated in MC versions newer than 1.21.10
+    //  See related Epic Fight issue
+    //  (although that's a different issue, it's also because of this Minecraft bug):
+    //  https://github.com/Epic-Fight/epicfight/issues/2174
+    private static void maybeHandleControlifyRelease() {
+        if (!ControlifyCompat.isModInstalled()) {
+            return;
+        }
+        final Optional<ControllerEntity> maybeController = ControlifyApi.get().getCurrentController();
+        if (maybeController.isEmpty()) {
+            return;
+        }
+        final ControllerEntity controller = maybeController.get();
+        for (KeyMapping keyMapping : TYPE_KEY_MAP.values()) {
+            final InputBindingSupplier inputBindingSupplier = ControlifyCompat.getInputBindingFromKeyMapping(keyMapping);
+            if (inputBindingSupplier == null) {
+                continue;
+            }
+            if (inputBindingSupplier.on(controller).justReleased()) {
+                handleRelease();
+            }
+        }
+    }
 
     private static void handleRelease() {
         if (shouldHandleInput()) {

--- a/src/main/java/com/p1nero/invincible/client/InputManager.java
+++ b/src/main/java/com/p1nero/invincible/client/InputManager.java
@@ -157,24 +157,31 @@ public class InputManager {
      * 松手时发包
      */
     private static void handleInput(int key, int action) {
-        LocalPlayerPatch playerPatch = ClientEngine.getInstance().getPlayerPatch();
-        if (playerPatch != null && Minecraft.getInstance().screen == null && !Minecraft.getInstance().isPaused()
-                && playerPatch.getSkill(SkillSlots.WEAPON_INNATE).getSkill() instanceof ComboBasicAttack) {
-            if (action == InputConstants.PRESS) {
-                for (KeyMapping keyMapping : TYPE_KEY_MAP.values()) {
-                    int keyId = keyMapping.getKey().getValue();
-                    if (key == keyId) {
-                        if (!INPUT_QUEUE.contains(keyId)) {
-                            INPUT_QUEUE.add(keyId);
-                        }
-                        KEY_STATE_CACHE.put(keyId, KEY_STATE_CACHE.getOrDefault(keyId, 0) + 1);
-                        clearReservedKeys();
+        final Minecraft minecraft = Minecraft.getInstance();
+        if (minecraft.screen != null || minecraft.isPaused()) {
+            return;
+        }
+        final LocalPlayerPatch playerPatch = ClientEngine.getInstance().getPlayerPatch();
+        if (playerPatch == null) {
+            return;
+        }
+        if (!(playerPatch.getSkill(SkillSlots.WEAPON_INNATE).getSkill() instanceof ComboBasicAttack)) {
+            return;
+        }
+        if (action == InputConstants.PRESS) {
+            for (KeyMapping keyMapping : TYPE_KEY_MAP.values()) {
+                int keyId = keyMapping.getKey().getValue();
+                if (key == keyId) {
+                    if (!INPUT_QUEUE.contains(keyId)) {
+                        INPUT_QUEUE.add(keyId);
                     }
+                    KEY_STATE_CACHE.put(keyId, KEY_STATE_CACHE.getOrDefault(keyId, 0) + 1);
+                    clearReservedKeys();
                 }
             }
-            if (action == InputConstants.RELEASE) {
-                tryRequestSkillExecute(true);
-            }
+        }
+        if (action == InputConstants.RELEASE) {
+            tryRequestSkillExecute(true);
         }
     }
 

--- a/src/main/java/com/p1nero/invincible/client/InputManager.java
+++ b/src/main/java/com/p1nero/invincible/client/InputManager.java
@@ -95,6 +95,7 @@ public class InputManager {
         if (event.phase == TickEvent.Phase.START || Minecraft.getInstance().player == null) {
             return;
         }
+        handleKeyBinds();
         LocalPlayerPatch localPlayerPatch = ClientEngine.getInstance().getPlayerPatch();
         if (localPlayerPatch != null && Minecraft.getInstance().getConnection() != null) {
             //缓存的按键的处理
@@ -139,17 +140,35 @@ public class InputManager {
         }
     }
 
-    // TODO: Refactor handleInput() to not depend on any "InputEvent"s to support controllers.
-    //  See the related issue: https://github.com/GaylordFockerCN/EpicFight-Invincible/issues/3
-
     @SubscribeEvent
     public static void onMouseInput(InputEvent.MouseButton event) {
-        handleInput(event.getButton(), event.getAction());
+        onVanillaMouseOrKeyInput(event.getAction());
     }
 
     @SubscribeEvent
     public static void onKeyInput(InputEvent.Key event) {
-        handleInput(event.getKey(), event.getAction());
+        onVanillaMouseOrKeyInput(event.getAction());
+    }
+
+    private static void onVanillaMouseOrKeyInput(int action) {
+        if (action == InputConstants.RELEASE) {
+            handleRelease();
+        }
+    }
+
+    // TODO: handleRelease() is not called when using a controller,
+    //  this is mainly because Controlify key emulation does not work
+    //  "InputEvent"s, only vanilla KeyMapping.
+    //  The main reason why we use "InputEvent"s is that in Minecraft versions before 1.21.10,
+    //  "isDown()" method, (which is required to determine whether the key is down),
+    //  always returns "false" in MC 1.21.1 and 1.20.1 when there are
+    //  multiple keybinds bound to the same physical mouse button,
+    //  so the key release will be broken.
+
+    private static void handleRelease() {
+        if (shouldHandleInput()) {
+            tryRequestSkillExecute(true);
+        }
     }
 
     private static boolean shouldHandleInput() {
@@ -168,24 +187,19 @@ public class InputManager {
      * 按下时记录
      * 松手时发包
      */
-    private static void handleInput(int key, int action) {
+    private static void handleKeyBinds() {
         if (!shouldHandleInput()) {
             return;
         }
-        if (action == InputConstants.PRESS) {
-            for (KeyMapping keyMapping : TYPE_KEY_MAP.values()) {
-                int keyId = keyMapping.getKey().getValue();
-                if (key == keyId) {
-                    if (!INPUT_QUEUE.contains(keyId)) {
-                        INPUT_QUEUE.add(keyId);
-                    }
-                    KEY_STATE_CACHE.put(keyId, KEY_STATE_CACHE.getOrDefault(keyId, 0) + 1);
-                    clearReservedKeys();
+        for (KeyMapping keyMapping : TYPE_KEY_MAP.values()) {
+            int keyId = keyMapping.getKey().getValue();
+            while (keyMapping.consumeClick()) {
+                if (!INPUT_QUEUE.contains(keyId)) {
+                    INPUT_QUEUE.add(keyId);
                 }
+                KEY_STATE_CACHE.put(keyId, KEY_STATE_CACHE.getOrDefault(keyId, 0) + 1);
+                clearReservedKeys();
             }
-        }
-        if (action == InputConstants.RELEASE) {
-            tryRequestSkillExecute(true);
         }
     }
 

--- a/src/main/java/com/p1nero/invincible/client/InputManager.java
+++ b/src/main/java/com/p1nero/invincible/client/InputManager.java
@@ -152,20 +152,24 @@ public class InputManager {
         handleInput(event.getKey(), event.getAction());
     }
 
+    private static boolean shouldHandleInput() {
+        final Minecraft minecraft = Minecraft.getInstance();
+        if (minecraft.screen != null || minecraft.isPaused()) {
+            return false;
+        }
+        final LocalPlayerPatch playerPatch = ClientEngine.getInstance().getPlayerPatch();
+        if (playerPatch == null) {
+            return false;
+        }
+        return playerPatch.getSkill(SkillSlots.WEAPON_INNATE).getSkill() instanceof ComboBasicAttack;
+    }
+
     /**
      * 按下时记录
      * 松手时发包
      */
     private static void handleInput(int key, int action) {
-        final Minecraft minecraft = Minecraft.getInstance();
-        if (minecraft.screen != null || minecraft.isPaused()) {
-            return;
-        }
-        final LocalPlayerPatch playerPatch = ClientEngine.getInstance().getPlayerPatch();
-        if (playerPatch == null) {
-            return;
-        }
-        if (!(playerPatch.getSkill(SkillSlots.WEAPON_INNATE).getSkill() instanceof ComboBasicAttack)) {
+        if (!shouldHandleInput()) {
             return;
         }
         if (action == InputConstants.PRESS) {

--- a/src/main/java/com/p1nero/invincible/compat/controlify/ControlifyCompat.java
+++ b/src/main/java/com/p1nero/invincible/compat/controlify/ControlifyCompat.java
@@ -11,9 +11,11 @@ import dev.isxander.controlify.api.entrypoint.PreInitContext;
 import dev.isxander.controlify.bindings.BindContext;
 import dev.isxander.controlify.bindings.RadialIcons;
 import dev.isxander.controlify.utils.render.Blit;
+import net.minecraft.client.KeyMapping;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import yesman.epicfight.client.ClientEngine;
 import yesman.epicfight.client.world.capabilites.entitypatch.player.LocalPlayerPatch;
 
@@ -22,6 +24,31 @@ public class ControlifyCompat implements ControlifyEntrypoint {
     private static InputBindingSupplier secondaryAction;
     private static InputBindingSupplier specialAbility1;
     private static InputBindingSupplier specialAbility2;
+
+    private static boolean isModInstalled;
+
+    public static boolean isModInstalled() {
+        return isModInstalled;
+    }
+
+    // Hack: Since some parts of Invincible Lib stores KeyMapping,
+    // the KeyMapping is mapped to a Controlify input binding that can be used.
+    // This HACK can be eliminated in MC versions newer than 1.21.10
+    public static @Nullable InputBindingSupplier getInputBindingFromKeyMapping(@NotNull KeyMapping keyMapping) {
+        if (keyMapping == InvincibleKeyMappings.KEY1) {
+            return primaryAction;
+        }
+        if (keyMapping == InvincibleKeyMappings.KEY2) {
+            return secondaryAction;
+        }
+        if (keyMapping == InvincibleKeyMappings.KEY3) {
+            return specialAbility1;
+        }
+        if (keyMapping == InvincibleKeyMappings.KEY4) {
+            return specialAbility2;
+        }
+        return null;
+    }
 
     @Override
     public void onControllersDiscovered(ControlifyApi controlify) {
@@ -35,6 +62,7 @@ public class ControlifyCompat implements ControlifyEntrypoint {
 
     @Override
     public void onControlifyPreInit(PreInitContext context) {
+        isModInstalled = true;
         final ControlifyBindApi registrar = ControlifyBindApi.get();
         registerCustomRadialIcons();
         registrar.registerBindContext(IN_GAME_EPIC_FIGHT_CONTEXT);


### PR DESCRIPTION
This restores Controlify support, and I have tested Yamato and other Nightfall weapons on both mouse/keyboard and a controller; everything seems to work.

While the user-facing behavior is fine, the implementation details are not ideal at all.

Normally, we should use `ClientTickEvent` without any `InputEvent`s by just using `KeyMapping#consumeClick` and `KeyMapping#isDown` to support Controlify key emulation, no need for `onKeyInput`, `onMouseInput`, and `maybeHandleControlifyRelease`, though, sadly, there is a Minecraft bug that causes the `KeyMapping#isDown` to return `false` whenever there are other key mappings that share the same physical mouse button (e.g., left mouse button), so it's always `false`, even if actaully pressed. This issue does not exist in MC 1.21.10 (see also https://github.com/Epic-Fight/epicfight/issues/2174)

> [!TIP]
> The way that key bind presses are handled in a universal way inside `handleKeyBinds`, so it works for both controllers and mouse/keyboard with no need to depend on Controlify directly.
> Continue reading to know more

Since `KeyMapping#isDown` may incorrectly report `false` in older MC versions as 1.20.1 and 1.21.1, we can't detect the mouse release universally, so we have to handle that separately.
I added the `handleRelease` method, which is shared, but the way it's called is completely different; it could be called from `InputEvents`s, or from `maybeHandleControlifyRelease`, which is called in every client tick event.

> [!NOTE]
> When updating to MC 1.21.10, we could remove `ControlifyCompat#maybeHandleControlifyRelease`, `ControlifyCompat#getInputBindingFromKeyMapping`, `ControlifyCompat#isModInstalled`, `InputManager#onVanillaMouseOrKeyInput`, `InputManager#onKeyInput`, and `InputManager#onMouseInput`, and instead handle the mouse release inside `InputManager#handleKeyBinds`.

> [!NOTE]
> Alternatively, we could just not support the longpress/release feature when using a controller, to eliminate all these ugly hacks, and keep it supported only on mouse and keyboard.

The first 3 commits make some good refactoring and cleanup, but the last is completely messy, and I couldn't find any better workarounds. It works, but it's hard to maintain or even understand.

https://github.com/user-attachments/assets/d310b338-896a-4ac8-9cf6-1561dfbd5d58



