### PR TITLE
Remove deprecated "Epic Fight: Controlify" addon

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -145,6 +145,7 @@ dependencies {
     minecraft "net.minecraftforge:forge:${minecraft_version}-${forge_version}"
     annotationProcessor 'org.spongepowered:mixin:0.8.5:processor'
     implementation fg.deobf("maven.modrinth:epic-fight:20.13.5-1.20.1")
+    implementation fg.deobf("maven.modrinth:epic-fight:${project.epicfight_version}")
 
     implementation fg.deobf("dev.echoellet:controlify-forgified:${project.controlify_version}")
     runtimeOnly fg.deobf("maven.modrinth:yacl:3.6.6+1.20.1-forge") // Required to run Controlify (transitive dependency)

--- a/build.gradle
+++ b/build.gradle
@@ -147,7 +147,7 @@ dependencies {
     implementation fg.deobf("maven.modrinth:epic-fight:20.13.5-1.20.1")
     implementation fg.deobf("maven.modrinth:epic-fight:${project.epicfight_version}")
 
-    implementation fg.deobf("dev.echoellet:controlify-forgified:${project.controlify_version}")
+    compileOnly fg.deobf("dev.echoellet:controlify-forgified:${project.controlify_version}")
     runtimeOnly fg.deobf("maven.modrinth:yacl:3.6.6+1.20.1-forge") // Required to run Controlify (transitive dependency)
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -46,4 +46,5 @@ mod_authors=P1nero
 mod_description=Make Epic Fight addon developers easier to create complex combo weapon types.
 
 # Dependencies
-controlify_version=2.1.6-mc1.20.1-forge
+epicfight_version=20.13.5-1.20.1
+controlify_version=2.1.7-mc1.20.1-forge

--- a/src/main/java/com/p1nero/invincible/client/InputManager.java
+++ b/src/main/java/com/p1nero/invincible/client/InputManager.java
@@ -6,9 +6,10 @@ import com.p1nero.invincible.InvincibleMod;
 import com.p1nero.invincible.api.events.Side;
 import com.p1nero.invincible.api.skill.ComboNode;
 import com.p1nero.invincible.api.skill.ComboType;
-import com.p1nero.invincible.capability.InvinciblePlayerCapabilityProvider;
 import com.p1nero.invincible.capability.InvinciblePlayer;
+import com.p1nero.invincible.capability.InvinciblePlayerCapabilityProvider;
 import com.p1nero.invincible.compat.controlify.ControlifyCompat;
+import com.p1nero.invincible.compat.controlify.ControlifyModAvailability;
 import com.p1nero.invincible.gameassets.InvincibleSkillDataKeys;
 import com.p1nero.invincible.skill.AbstractInvincibleInnateSkill;
 import com.p1nero.invincible.skill.ComboBasicAttack;
@@ -174,7 +175,7 @@ public class InputManager {
     //  (although that's a different issue, it's also because of this Minecraft bug):
     //  https://github.com/Epic-Fight/epicfight/issues/2174
     private static void maybeHandleControlifyRelease() {
-        if (!ControlifyCompat.isModInstalled()) {
+        if (!ControlifyModAvailability.isModInstalled()) {
             return;
         }
         final Optional<ControllerEntity> maybeController = ControlifyApi.get().getCurrentController();

--- a/src/main/java/com/p1nero/invincible/compat/controlify/ControlifyCompat.java
+++ b/src/main/java/com/p1nero/invincible/compat/controlify/ControlifyCompat.java
@@ -17,20 +17,12 @@ import net.minecraft.resources.ResourceLocation;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import yesman.epicfight.client.ClientEngine;
-import yesman.epicfight.client.world.capabilites.entitypatch.player.LocalPlayerPatch;
-import yesman.epicfight.world.capabilities.EpicFightCapabilities;
 
 public class ControlifyCompat implements ControlifyEntrypoint {
     private static InputBindingSupplier primaryAction;
     private static InputBindingSupplier secondaryAction;
     private static InputBindingSupplier specialAbility1;
     private static InputBindingSupplier specialAbility2;
-
-    private static boolean isModInstalled;
-
-    public static boolean isModInstalled() {
-        return isModInstalled;
-    }
 
     // Hack: Since some parts of Invincible Lib stores KeyMapping,
     // the KeyMapping is mapped to a Controlify input binding that can be used.
@@ -63,7 +55,7 @@ public class ControlifyCompat implements ControlifyEntrypoint {
 
     @Override
     public void onControlifyPreInit(PreInitContext context) {
-        isModInstalled = true;
+        ControlifyModAvailability.setIsModInstalled(true);
         final ControlifyBindApi registrar = ControlifyBindApi.get();
         registerCustomRadialIcons();
         registrar.registerBindContext(IN_GAME_EPIC_FIGHT_CONTEXT);
@@ -142,14 +134,7 @@ public class ControlifyCompat implements ControlifyEntrypoint {
             InvincibleMod.rl("epicfight_combat"),
             mc -> {
                 final boolean isInGame = mc.screen == null && mc.level != null && mc.player != null;
-                if (isInGame) {
-                    final LocalPlayerPatch localPlayerPatch = EpicFightCapabilities.getEntityPatch(mc.player, LocalPlayerPatch.class);
-                    if (localPlayerPatch == null) {
-                        return false;
-                    }
-                    return localPlayerPatch.isEpicFightMode();
-                }
-                return false;
+                return isInGame && ClientEngine.getInstance().isBattleMode();
             }
     );
 

--- a/src/main/java/com/p1nero/invincible/compat/controlify/ControlifyModAvailability.java
+++ b/src/main/java/com/p1nero/invincible/compat/controlify/ControlifyModAvailability.java
@@ -1,0 +1,14 @@
+package com.p1nero.invincible.compat.controlify;
+
+public final class ControlifyModAvailability {
+    private ControlifyModAvailability() {}
+    private static boolean isModInstalled;
+
+    public static boolean isModInstalled() {
+        return isModInstalled;
+    }
+
+    public static void setIsModInstalled(final boolean isModInstalled) {
+        ControlifyModAvailability.isModInstalled = isModInstalled;
+    }
+}


### PR DESCRIPTION
Similar to https://github.com/GaylordFockerCN/SwordSoaring-Reborn/pull/10, but for this repo with a bug fix.

* The Epic Fight X Controlify is now built-in and officially supported by recent versions of Epic Fight, even in 1.20.1, so only [Controlify: Forgified](https://modrinth.com/mod/controlify-forgified) is needed to use a controller. This has no impact on the user behavior; it's just for the development environment. There is no reason to backport this to 1.21.1, as older Epic Fight 1.21.1 versions already have built-in Controlify support.
* **Important:** Fix a runtime crash if the Controlify mod is not installed.
