### PR TITLE
[1.21.1] Restore Controlify support

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,3 @@
+- Added [Controlify](https://modrinth.com/mod/controlify) compatibility for controller
+  support.
+  [#9](https://github.com/GaylordFockerCN/EpicFight-Invincible/issues/9)

--- a/src/main/java/com/p1nero/invincible/client/InputManager.java
+++ b/src/main/java/com/p1nero/invincible/client/InputManager.java
@@ -11,8 +11,13 @@ import com.p1nero.invincible.api.combo.ComboNode;
 import com.p1nero.invincible.api.combo.ComboType;
 import com.p1nero.invincible.attachment.InvincibleAttachments;
 import com.p1nero.invincible.attachment.InvinciblePlayer;
+import com.p1nero.invincible.compat.controlify.ControlifyCompat;
+import com.p1nero.invincible.compat.controlify.ControlifyModAvailability;
 import com.p1nero.invincible.gameassets.InvincibleSkillDataKeys;
 import com.p1nero.invincible.skill.ComboBasicAttack;
+import dev.isxander.controlify.api.ControlifyApi;
+import dev.isxander.controlify.api.bind.InputBindingSupplier;
+import dev.isxander.controlify.controller.ControllerEntity;
 import net.minecraft.client.KeyMapping;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.Options;
@@ -44,7 +49,7 @@ public class InputManager {
     private static int reserveCounter;
     private static long lastInputTime;
     private static long inputInterval;
-    private static final BiMap<ComboType, KeyMapping> TYPE_KEY_MAP = HashBiMap.create();
+    private static final BiMap<ComboType, @NotNull KeyMapping> TYPE_KEY_MAP = HashBiMap.create();
     private static BiMap<KeyMapping, ComboType> KEY_TYPE_MAP = HashBiMap.create();
     private static final Map<Integer, Integer> KEY_STATE_CACHE = new HashMap<>();
     private static final Queue<Integer> INPUT_QUEUE = new ArrayDeque<>();
@@ -99,6 +104,8 @@ public class InputManager {
      */
     @SubscribeEvent
     public static void onClientTick(ClientTickEvent.Post event) {
+        handleKeyBinds();
+        maybeHandleControlifyRelease();
         LocalPlayerPatch localPlayerPatch = ClientEngine.getInstance().getPlayerPatch();
 
         if (localPlayerPatch != null) {
@@ -164,42 +171,90 @@ public class InputManager {
         }
     }
 
-    // TODO: Refactor handleInput() to not depend on any "InputEvent"s to support controllers.
-    //  See the related issue: https://github.com/GaylordFockerCN/EpicFight-Invincible/issues/3
-
     @SubscribeEvent
     public static void onMouseInput(InputEvent.MouseButton.Pre event) {
-        handleInput(event.getButton(), event.getAction());
+        onVanillaMouseOrKeyInput(event.getAction());
     }
 
     @SubscribeEvent
     public static void onKeyInput(InputEvent.Key event) {
-        handleInput(event.getKey(), event.getAction());
+        onVanillaMouseOrKeyInput(event.getAction());
+    }
+
+    private static void onVanillaMouseOrKeyInput(int action) {
+        if (action == InputConstants.RELEASE) {
+            handleRelease();
+        }
+    }
+
+    // TODO: Ideally, we should call handleRelease() from one place and provide
+    //  standard handling for both controllers and mouse/keyboard without depending on "InputEvents"s
+    //  or Controlify APIs directly.
+    //  However, it's tricky since "KeyMapping#isDown" returns false whenever there are multiple keybinds
+    //  that are bound to the same physical mouse button.
+    //  As a workaround, we handle mouse/keyboard via "InputEvents"s, and Controlify via this method.
+    //  The keybind presses handling is shared for all inputs using handleKeyBinds()
+    //  This HACK can be eliminated in MC versions newer than 1.21.10
+    //  See related Epic Fight issue
+    //  (although that's a different issue, it's also because of this Minecraft bug):
+    //  https://github.com/Epic-Fight/epicfight/issues/2174
+    //  https://github.com/GaylordFockerCN/EpicFight-Invincible/issues/11
+
+    private static void maybeHandleControlifyRelease() {
+        if (!ControlifyModAvailability.isModInstalled()) {
+            return;
+        }
+        final Optional<ControllerEntity> maybeController = ControlifyApi.get().getCurrentController();
+        if (maybeController.isEmpty()) {
+            return;
+        }
+        final ControllerEntity controller = maybeController.get();
+        for (KeyMapping keyMapping : TYPE_KEY_MAP.values()) {
+            final InputBindingSupplier inputBindingSupplier = ControlifyCompat.getInputBindingFromKeyMapping(keyMapping);
+            if (inputBindingSupplier == null) {
+                continue;
+            }
+            if (inputBindingSupplier.on(controller).justReleased()) {
+                handleRelease();
+            }
+        }
+    }
+
+    private static void handleRelease() {
+        if (shouldHandleInput()) {
+            tryRequestSkillExecute(true);
+        }
+    }
+
+    private static boolean shouldHandleInput() {
+        final Minecraft minecraft = Minecraft.getInstance();
+        if (minecraft.screen != null || minecraft.isPaused()) {
+            return false;
+        }
+        final LocalPlayerPatch playerPatch = ClientEngine.getInstance().getPlayerPatch();
+        if (playerPatch == null) {
+            return false;
+        }
+        return playerPatch.getSkill(SkillSlots.WEAPON_INNATE).getSkill() instanceof ComboBasicAttack;
     }
 
     /**
      * 按下时记录
      * 松手时发包
      */
-    private static void handleInput(int key, int action) {
-        LocalPlayerPatch playerPatch = ClientEngine.getInstance().getPlayerPatch();
-        if (playerPatch != null && Minecraft.getInstance().screen == null && !Minecraft.getInstance().isPaused()
-                && playerPatch.getSkill(SkillSlots.WEAPON_INNATE).getSkill() instanceof ComboBasicAttack) {
-            if (action == InputConstants.PRESS) {
-                for (KeyMapping keyMapping : TYPE_KEY_MAP.values()) {
-                    int keyId = keyMapping.getKey().getValue();
-                    if (key == keyId) {
-                        handleOnPress(keyMapping);
-                        if (!INPUT_QUEUE.contains(keyId)) {
-                            INPUT_QUEUE.add(keyId);
-                        }
-                        KEY_STATE_CACHE.put(keyId, KEY_STATE_CACHE.getOrDefault(keyId, 0) + 1);
-                        clearReservedKeys();
-                    }
+    private static void handleKeyBinds() {
+        for (KeyMapping keyMapping : TYPE_KEY_MAP.values()) {
+            int keyId = keyMapping.getKey().getValue();
+            while (keyMapping.consumeClick()) {
+                if (!shouldHandleInput()) {
+                    continue;
                 }
-            }
-            if (action == InputConstants.RELEASE) {
-                tryRequestSkillExecute(true);
+                handleOnPress(keyMapping);
+                if (!INPUT_QUEUE.contains(keyId)) {
+                    INPUT_QUEUE.add(keyId);
+                }
+                KEY_STATE_CACHE.put(keyId, KEY_STATE_CACHE.getOrDefault(keyId, 0) + 1);
+                clearReservedKeys();
             }
         }
     }

--- a/src/main/java/com/p1nero/invincible/compat/controlify/ControlifyCompat.java
+++ b/src/main/java/com/p1nero/invincible/compat/controlify/ControlifyCompat.java
@@ -12,9 +12,11 @@ import dev.isxander.controlify.bindings.BindContext;
 import dev.isxander.controlify.bindings.RadialIcons;
 import dev.isxander.controlify.utils.render.Blit;
 import dev.isxander.controlify.utils.render.CGuiPose;
+import net.minecraft.client.KeyMapping;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import yesman.epicfight.client.ClientEngine;
 
 public class ControlifyCompat implements ControlifyEntrypoint {
@@ -22,6 +24,25 @@ public class ControlifyCompat implements ControlifyEntrypoint {
     private static InputBindingSupplier secondaryAction;
     private static InputBindingSupplier specialAbility1;
     private static InputBindingSupplier specialAbility2;
+
+    // Hack: Since some parts of Invincible Lib stores KeyMapping,
+    // the KeyMapping is mapped to a Controlify input binding that can be used.
+    // This HACK can be eliminated in MC versions newer than 1.21.10
+    public static @Nullable InputBindingSupplier getInputBindingFromKeyMapping(@NotNull KeyMapping keyMapping) {
+        if (keyMapping == InvincibleKeyMappings.KEY1) {
+            return primaryAction;
+        }
+        if (keyMapping == InvincibleKeyMappings.KEY2) {
+            return secondaryAction;
+        }
+        if (keyMapping == InvincibleKeyMappings.KEY3) {
+            return specialAbility1;
+        }
+        if (keyMapping == InvincibleKeyMappings.KEY4) {
+            return specialAbility2;
+        }
+        return null;
+    }
 
     @Override
     public void onControllersDiscovered(ControlifyApi controlify) {
@@ -35,6 +56,7 @@ public class ControlifyCompat implements ControlifyEntrypoint {
 
     @Override
     public void onControlifyPreInit(PreInitContext context) {
+        ControlifyModAvailability.setIsModInstalled(true);
         final ControlifyBindApi registrar = ControlifyBindApi.get();
         registerCustomRadialIcons();
         registrar.registerBindContext(IN_GAME_EPIC_FIGHT_CONTEXT);

--- a/src/main/java/com/p1nero/invincible/compat/controlify/ControlifyModAvailability.java
+++ b/src/main/java/com/p1nero/invincible/compat/controlify/ControlifyModAvailability.java
@@ -1,0 +1,16 @@
+package com.p1nero.invincible.compat.controlify;
+
+public final class ControlifyModAvailability {
+    private ControlifyModAvailability() {
+    }
+
+    private static boolean isModInstalled;
+
+    public static boolean isModInstalled() {
+        return isModInstalled;
+    }
+
+    public static void setIsModInstalled(final boolean isModInstalled) {
+        ControlifyModAvailability.isModInstalled = isModInstalled;
+    }
+}


### PR DESCRIPTION
Ports all of #8, #10 and #13 to keep `1.21.1` and `1.20.1` branches in sync, to prepare for the next PR that aims to addres_s #11

- *Fixes #9*

Tested with Sword Soaring `1.21.1`, but not NightFall, since it's not ported yet; however, this keeps the changes similar to the current `1.20.1`, which is tested.