### PR TITLE
Fix dedicated-server NPE in DuplicateAnimationBuilder.nextAccessor masking earlier registration failures

### DIFF
--- a/src/main/java/com/p1nero/invincible/api/neoforgeevent/DuplicateAnimationRegistryEvent.java
+++ b/src/main/java/com/p1nero/invincible/api/neoforgeevent/DuplicateAnimationRegistryEvent.java
@@ -1,9 +1,11 @@
 package com.p1nero.invincible.api.neoforgeevent;
 
+import com.mojang.logging.LogUtils;
 import com.p1nero.invincible.mixin.AnimationManagerAccessor;
 import net.minecraft.resources.ResourceLocation;
 import net.neoforged.bus.api.Event;
 import net.neoforged.fml.event.IModBusEvent;
+import org.slf4j.Logger;
 import yesman.epicfight.api.animation.AnimationManager;
 import yesman.epicfight.api.animation.types.StaticAnimation;
 
@@ -15,6 +17,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 
 public class DuplicateAnimationRegistryEvent extends Event implements IModBusEvent {
+    private static final Logger LOGGER = LogUtils.getLogger();
     private final List<DuplicateAnimationBuilder> builders = new ArrayList<>();
     private final Set<String> namespaces = new HashSet<>();
 
@@ -34,6 +37,15 @@ public class DuplicateAnimationRegistryEvent extends Event implements IModBusEve
     public record DuplicateAnimationBuilder(String namespace, Consumer<DuplicateAnimationBuilder> task) {
 
         public <T extends StaticAnimation> AnimationManager.AnimationAccessor<T> nextAccessor(AnimationManager.AnimationAccessor<?> original, Function<AnimationManager.AnimationAccessor<T>, T> onLoad) {
+            if (original == null) {
+                // The original accessor is still null if Epic Fight's animation registration failed
+                // before it was assigned (e.g. another mod's animation builder crashed on a dedicated
+                // server). FML keeps draining the deferred work queue after such a failure, so we get
+                // here anyway. Log and skip instead of throwing, otherwise the NPE hides the real error.
+                LOGGER.error("Cannot duplicate an animation into '{}': the original accessor is null. An earlier animation registration probably failed, check the log above.", namespace);
+                return null;
+            }
+
             ResourceLocation selfName = ResourceLocation.fromNamespaceAndPath(namespace, original.registryName().getPath());
             AnimationManager.AnimationAccessor<T> accessor = DuplicateAnimationAccessorImpl.create(original.registryName(), selfName, getInstance().getAnimations().size() + 1, true, onLoad);
 


### PR DESCRIPTION
**What happens**
On a dedicated server, if any earlier deferred-work task fails during mod construction (e.g. an unrelated mod's broken mixin preventing an Epic Fight animation class from loading), FML still drains the remaining queue. The demo duplicate-animation registration then calls `DuplicateAnimationBuilder.nextAccessor` with a `null` base accessor and crashes with:

```
java.lang.NullPointerException: Cannot invoke "yesman.epicfight.api.animation.AnimationManager$AnimationAccessor.registryName()" because "original" is null
    at com.p1nero.invincible.api.neoforgeevent.DuplicateAnimationRegistryEvent$DuplicateAnimationBuilder.nextAccessor(DuplicateAnimationRegistryEvent.java:37)
    at com.p1nero.invincible.gameassets.InvincibleDuplicateDemoAnimations.lambda$registerAnimations$4(InvincibleDuplicateDemoAnimations.java:28)
```

Since this NPE becomes the most visible "Failed to start the minecraft server" error, it hides the real root cause and makes users report the crash against Invincible.

**Environment where I hit it:** Invincible 21.15.8.1, Epic Fight 21.17.3.1, NeoForge 21.1.234, MC 1.21.1, dev dedicated server.

**Fix:** guard `nextAccessor` against a `null` original accessor — log an explicit error that points at the earlier failure and skip the duplication instead of throwing. No behavior change when the base accessor resolved normally.

Happy to adjust style/logging if you prefer a different shape. Thanks for the mod!
